### PR TITLE
Feature/remove redshift as integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ To run the macro, simply paste the following in a **.sql** file inside your dbt 
 
 ```sql
 -- Table Structure Report
---> db_connection can be ['snowflake', 'postgres' or 'redshift']
+--> db_connection can be ['snowflake' or 'postgres']
 {{ table_structure_report(
-    old_db = 'old_database'
-    , old_schema = 'old_schema'
+    db_connection = 'postgres'
+    , old_db = 'your_legacy_database'
+    , old_schema = 'your_legacy_schema'
     , old_table = 'example_old_model'
-    , new_db = 'new_database'
-    , new_schema = 'new_schema'
+    , new_db = 'your_refactored_database'
+    , new_schema = 'your_refactored_schema'
     , new_table = 'example_refactored_model'
-    , db_connection = 'postgres'
     , date_column = 'created_date'
 ) }}
 ```
@@ -199,11 +199,11 @@ Note that this macro follows the same shape as the previous one, the column_matc
 {% endset %}
 
 -- Run audit macro
---> db_connection can be ['snowflake', 'postgres' or 'redshift']
+--> db_connection can be ['snowflake' or 'postgres']
 {{ column_values_report(
-    primary_key = 'id'
+    db_connection = 'postgres'
+    , primary_key = 'id'
     , model_name = 'ExampleModel'
-    , db_connection = 'postgres'
     , old_query = old_etl_relation_query
     , new_query = new_etl_relation_query
     , columns_to_compare = column_variables

--- a/macros/column_match_report.sql
+++ b/macros/column_match_report.sql
@@ -49,7 +49,7 @@ with
     , report_union as (
         select * from {{ columns_to_compare[0] }}_cte
         {% for column in columns_to_compare[1:] %}
-        union
+        union all
         select * from {{ column }}_cte
         {% endfor %}
     )

--- a/macros/column_values_report.sql
+++ b/macros/column_values_report.sql
@@ -10,7 +10,7 @@ with
     , {{ column }}_old as (
         select
             '{{ column }}' as column_name
-            {% if db_connection == 'postgres' or db_connection == 'redshift' %}
+            {% if db_connection == 'postgres' %}
             , pg_typeof({{ column }}) as old_data_type
             {% endif %}
             {% if db_connection == 'snowflake' %}
@@ -23,7 +23,7 @@ with
     , {{ column }}_new as (
         select
             '{{ column }}' as column_name
-            {% if db_connection == 'postgres' or db_connection == 'redshift' %}
+            {% if db_connection == 'postgres' %}
             , pg_typeof({{ column }}) as new_data_type
             {% endif %}
             {% if db_connection == 'snowflake' %}
@@ -37,8 +37,8 @@ with
         select
             '{{ column }}' as column_name
             , count(distinct {{ column }}) as old_distinct_count
-            , min({{ column }})::text as old_min_value
-            , max({{ column }})::text as old_max_value
+            , cast(min({{ column }}) as text) as old_min_value
+            , cast(max({{ column }}) as text) as old_max_value
         from old_query
     )
 
@@ -46,8 +46,8 @@ with
         select
             '{{ column }}' as column_name
             , count(distinct {{ column }}) as new_distinct_count
-            , min({{ column }})::text as new_min_value
-            , max({{ column }})::text as new_max_value
+            , cast(min({{ column }}) as text) as new_min_value
+            , cast(max({{ column }}) as text) as new_max_value
         from new_query
     )
 
@@ -100,7 +100,7 @@ with
     , report_union as (
         select * from {{ columns_to_compare[0] }}_joined
         {% for column in columns_to_compare[1:] %}
-        union
+        union all
         select * from {{ column }}_joined
         {% endfor %}
     )

--- a/macros/table_structure_report.sql
+++ b/macros/table_structure_report.sql
@@ -20,7 +20,7 @@ with
     , missing_from_old as (
         select
             'Old' as model
-            {% if db_connection == 'postgres' or db_connection == 'redshift' %}
+            {% if db_connection == 'postgres' %}
             , string_agg(new_columns_query.column_name, '| ') as missing_columns
             {% endif %}
             {% if db_connection == 'snowflake' %}
@@ -35,7 +35,7 @@ with
     , missing_from_new as (
         select
             'New' as model
-            {% if db_connection == 'postgres' or db_connection == 'redshift' %}
+            {% if db_connection == 'postgres' %}
             , string_agg(old_columns_query.column_name, '| ') as missing_columns
             {% endif %}
             {% if db_connection == 'snowflake' %}
@@ -52,8 +52,8 @@ with
             'Old' as model
             , count(*) as row_count
             {% if date_column is not none %}
-            , min({{ date_column }})::timestamp as min_{{ date_column }}
-            , max({{ date_column }})::timestamp as max_{{ date_column }}
+            , cast(min({{ date_column }}) as timestamp) as min_{{ date_column }}
+            , cast(max({{ date_column }}) as timestamp) as max_{{ date_column }}
             {% endif %}
         from {{ ref(old_table)}}
     )
@@ -90,8 +90,8 @@ with
             'New' as model
             , count(*) as row_count
             {% if date_column is not none %}
-            , min({{ date_column }})::timestamp as min_{{ date_column }}
-            , max({{ date_column }})::timestamp as max_{{ date_column }}
+            , cast(min({{ date_column }}) as timestamp) as min_{{ date_column }}
+            , cast(max({{ date_column }}) as timestamp) as max_{{ date_column }}
             {% endif %}
         from {{ ref(new_table)}}
     )
@@ -125,7 +125,7 @@ with
 
     , cte_union as (
         select * from old_join
-        union
+        union all
         select * from new_join
     )
 

--- a/models/example/audit_column_values_report.sql
+++ b/models/example/audit_column_values_report.sql
@@ -24,11 +24,11 @@
 {% endset %}
 
 -- Run audit macro
---> db_connection can be ['snowflake', 'postgres' or 'redshift']
+--> db_connection can be ['snowflake' or 'postgres']
 {{ column_values_report(
-    primary_key = 'id'
+    db_connection = 'postgres'
+    , primary_key = 'id'
     , model_name = 'ExampleModel'
-    , db_connection = 'postgres'
     , old_query = old_etl_relation_query
     , new_query = new_etl_relation_query
     , columns_to_compare = column_variables

--- a/models/example/audit_table_structure_report.sql
+++ b/models/example/audit_table_structure_report.sql
@@ -1,12 +1,12 @@
 -- Table Structure Report
---> db_connection can be ['snowflake', 'postgres' or 'redshift']
+--> db_connection can be ['snowflake' or 'postgres']
 {{ table_structure_report(
-    old_db = 'metabase'
-    , old_schema = 'dev'
+    db_connection = 'postgres'
+    , old_db = 'your_legacy_db'
+    , old_schema = 'your_legacy_schema'
     , old_table = 'example_legacy_model'
-    , new_db = 'metabase'
-    , new_schema = 'dev'
+    , new_db = 'your_refactored_db'
+    , new_schema = 'your_refactored_schema'
     , new_table = 'example_refactored_model'
-    , db_connection = 'postgres'
     , date_column = 'created_date'
 ) }}


### PR DESCRIPTION
## Overview
This PR aims to remove Redshift as a possible integration, while tests have not been finished.

## Key changes
- Removed Redshift as a possible integration. Postgres and Snowflake remain;
- Updated macros code in order to facilitate upcoming Bigquery and Redshift integration.

## Related links

## Checklist
- [x] All models, whether directly changed by this PR or not, run successfully.
- [x] Testing:
    - [x] All added/modified models and columns are documented and tested in `schema.yml` files.
    - [x] All tests pass. **OR**    
    _Check one:_
    - [ ] There are no new test failures, whether or not the existing model was intentionally changed for this PR.
    - [ ] This PR causes new test failures and there is a plan in place for addressing them.